### PR TITLE
Defined new boundary for EM bright region

### DIFF
--- a/configFile.ini
+++ b/configFile.ini
@@ -1,8 +1,8 @@
 [Paths]
-coincPath = /home/shaon/analysis/o2/EM_Bright/all_coincs
-psdPath = /home/shaon/analysis/o2/EM_Bright/all_psds
-results = /home/shaon/analysis/o2/EM_Bright/all_source_classifications
-logs = /home/shaon/analysis/o2/EM_Bright/logs
+coincPath = ./all_coincs
+psdPath = ./all_psds
+results = ./all_source_classifications
+logs = ./logs
 numTrials = 5
 wait = 5
 

--- a/em_progenitors.py
+++ b/em_progenitors.py
@@ -17,9 +17,6 @@
 from __future__ import division
 import math
 import numpy as np
-import pycbc
-import pycbc.tmpltbank.em_progenitors
-#from pycbc.tmpltbank import NS_SEQUENCE_FILE_DIRECTORY
 import os.path
 import scipy.optimize
 import scipy.interpolate
@@ -286,8 +283,8 @@ def load_ns_sequence(eos_name):
     ns_sequence = []
 
     if eos_name == '2H':
-        ns_sequence_path = os.path.join(pycbc.tmpltbank.NS_SEQUENCE_FILE_DIRECTORY, 'equil_2H.dat')
-        #ns_sequence_path = os.path.join(NS_SEQUENCE_FILE_DIRECTORY, 'equil_2H.dat')
+
+	ns_sequence_path = os.path.join('/home/deep.chatterjee/LIGOProject/INJECTIONs', 'equil_2H.dat')
         ns_sequence = np.loadtxt(ns_sequence_path)
     else:
         print 'Only the 2H EOS is currently supported!'
@@ -418,10 +415,9 @@ def remnant_mass(eta, ns_g_mass, ns_sequence, chi, incl, shift):
     """
     # Sanity checks
     if not (eta>0. and eta<=0.25 and abs(chi)<=1):
-        return [0] ### CHECK ###
-#         print 'The BH spin magnitude must be <=1 and eta must be between 0 and 0.25'
-#         print 'This script was launched with ns_mass={0}, eta={1}, chi={2}, inclination={3}\n'.format(ns_b_mass, eta, chi, incl)
-#         raise Exception('Unphysical parameters!')
+        print 'The BH spin magnitude must be <=1 and eta must be between 0 and 0.25'
+        print 'This script was launched with ns_mass={0}, eta={1}, chi={2}, inclination={3}\n'.format(ns_b_mass, eta, chi, incl)
+        raise Exception('Unphysical parameters!')
 
     # Binary mass ratio define to be > 1
     q = (1+math.sqrt(1-4*eta)-2*eta)/eta*0.5
@@ -516,7 +512,7 @@ def remnant_mass_ulim(eta, ns_g_mass, bh_spin_z, ns_sequence, max_ns_g_mass, shi
     default_remnant_mass = 100.
     if not ns_g_mass > max_ns_g_mass:
         bh_spin_inclination = np.arccos(bh_spin_z/bh_spin_magnitude)
-        remnant_mass_upper_limit = pycbc.tmpltbank.em_progenitors.remnant_mass(eta, ns_g_mass, ns_sequence, bh_spin_magnitude, bh_spin_inclination, shift)
+        remnant_mass_upper_limit = remnant_mass(eta, ns_g_mass, ns_sequence, bh_spin_magnitude, bh_spin_inclination, shift)
     else:
         remnant_mass_upper_limit = default_remnant_mass
 

--- a/genDiskMassProbability.py
+++ b/genDiskMassProbability.py
@@ -1,11 +1,12 @@
 import numpy as np
 import em_progenitors
-import readMassXML
+#import readMassXML
 import sys
 
 
 class genDiskMass:
-    def __init__(self, input, output, threshold):
+    def __init__(self, input, output, threshold):	# RE: different from Reed's patch here. Probably this does not need modification
+							# New instance variable used by Reed is already present as self.max_ns_g_mass
         '''
         input could be a posterior sample from lalinference output, 
         3D ambiguiity ellipsoid sample, 2D ambiguity ellipse samples 
@@ -36,8 +37,8 @@ class genDiskMass:
         self.eta = massRatio/((1 + massRatio)**2)
         self.mPrimary = (massRatio**(-0.6)) * mc * (1. + massRatio)**0.2
         self.mSecondary = (massRatio**0.4) * mc * (1. + massRatio)**0.2
-        NS_prob_2 = np.sum(self.mSecondary < 3.0)*100./len(self.mSecondary)
-        NS_prob_1 = np.sum(self.mPrimary < 3.0)*100./len(self.mPrimary)
+        NS_prob_2 = np.sum(self.mSecondary < self.max_ns_g_mass)*100./len(self.mSecondary) # RE: Max NS mass was hardcoded as 3.0. Should be gotten from class variable
+        NS_prob_1 = np.sum(self.mPrimary < self.max_ns_g_mass)*100./len(self.mPrimary)
         return [NS_prob_1, NS_prob_2, self.computeRemMass()]
         
     def fromMassSpinAmbiguity(self):
@@ -52,8 +53,8 @@ class genDiskMass:
         self.chi = data[:,3]
         self.mPrimary = 0.5*mc*(self.eta**(-3./5.))*(1 + np.sqrt(1 - 4*self.eta))
         self.mSecondary = 0.5*mc*(self.eta**(-3./5.))*(1 - np.sqrt(1 - 4*self.eta))
-        NS_prob_2 = np.sum(self.mSecondary < 3.0)*100./len(self.mSecondary)
-        NS_prob_1 = np.sum(self.mPrimary < 3.0)*100./len(self.mPrimary)
+        NS_prob_2 = np.sum(self.mSecondary < self.max_ns_g_mass)*100./len(self.mSecondary)
+        NS_prob_1 = np.sum(self.mPrimary < self.max_ns_g_mass)*100./len(self.mPrimary)
         return [NS_prob_1, NS_prob_2, self.computeRemMass()]
 
     def fromEllipsoidSample(self):
@@ -69,8 +70,8 @@ class genDiskMass:
         self.chi = data[:,2]
         self.mPrimary = 0.5*mc*(self.eta**(-3./5.))*(1 + np.sqrt(1 - 4*self.eta))
         self.mSecondary = 0.5*mc*(self.eta**(-3./5.))*(1 - np.sqrt(1 - 4*self.eta))
-        NS_prob_2 = np.sum(self.mSecondary < 3.0)*100./len(self.mSecondary)
-        NS_prob_1 = np.sum(self.mPrimary < 3.0)*100./len(self.mPrimary)
+        NS_prob_2 = np.sum(self.mSecondary < self.max_ns_g_mass)*100./len(self.mSecondary)
+        NS_prob_1 = np.sum(self.mPrimary < self.max_ns_g_mass)*100./len(self.mPrimary)
         return [NS_prob_1, NS_prob_2, self.computeRemMass()]
 
         
@@ -89,5 +90,12 @@ class genDiskMass:
         return np.array(remnant_mass)
 
         
-
-
+# Reed's edit. New function to give the EM bright probability using new EMbright boundary
+    def computeEMBrightProb(self):
+	'''
+	Computes EM bright probability using remnant disk mass and max NS mass.
+	Draws the boundary of max NS mass and Foucart expression
+	'''
+	remMass = self.computeRemMass()
+	prob	= (self.mPrimary < self.max_ns_g_mass)*(self.mSecondary < self.max_ns_g_mass) + (remMass > self.threshold)
+	return 100.0*np.sum(prob > 0.) / len(prob)

--- a/lvalert-run_cbc_gstlal_lowmass.sh
+++ b/lvalert-run_cbc_gstlal_lowmass.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-python /home/shaon/ANALYSIS/DIAGNOSIS_EMBright/EM_Bright/sourceClassDriver.py /home/shaon/ANALYSIS/DIAGNOSIS_EMBright/EM_Bright/configFile.ini
+python ./sourceClassDriver.py ./configFile.ini

--- a/myLVAlertListen.ini
+++ b/myLVAlertListen.ini
@@ -1,5 +1,2 @@
 [cbc_gstlal_mdc]
-executable = /home/shaon/ANALYSIS/DIAGNOSIS_EMBright/EM_Bright/lvalert-run_cbc_gstlal_lowmass.sh
-
-[cbc_gstlal_highmass]
-executable = /home/shaon/ANALYSIS/DIAGNOSIS_EMBright/EM_Bright/lvalert-run_cbc_gstlal_lowmass.sh
+executable = ./lvalert-run_cbc_gstlal_lowmass.sh

--- a/sourceClassDriver.py
+++ b/sourceClassDriver.py
@@ -58,7 +58,6 @@ def readCoinc(CoincFile):
     return [mass1[index], mass2[index], chi1[index], snr[index], str(ifo[index])]
 
 
-
 #########################################################################################
 
 ### Reading information from config file ###
@@ -153,14 +152,16 @@ if streamdata['alert_type'] == 'new':
     if ~np.any( np.isnan(samples_sngl[0]) ): 
         diskMassObject_sngl = genDiskMassProbability.genDiskMass(samples_sngl, 'test', remMassThreshold)
         [NS_prob_1_sngl, NS_prob_2_sngl, diskMass_sngl] = diskMassObject_sngl.fromEllipsoidSample()
-        em_bright_prob_sngl = np.sum((diskMass_sngl > 0.)*100./len(diskMass_sngl))
+        #em_bright_prob_sngl = np.sum((diskMass_sngl > 0.)*100./len(diskMass_sngl))
+        em_bright_prob_sngl = diskMassObject_sngl.computeEMBrightProb() # RE: Probability using new EM bright boundary
+	#NS_prob_1_sngl, NS_prob_2_sngl, em_bright_prob_sngl = diskMassObject_sngl.computeEMBrightProb()
 
     else:
         log.writelines(str(datetime.datetime.today()) + '\t' + 'Return was NaNs\n')
         [NS_prob_2_sngl, em_bright_prob_sngl] = [0., 0.]
         message = 'EM-Bright probabilities computation failed for trigger + ' + graceid + '\n'
 
-        gdb.writeLog(graceid, message, tagname='em_follow')
+        #gdb.writeLog(graceid, message, tagname='em_follow')
         end = Time.time()
         log.writelines(str(datetime.datetime.today()) + '\t' + 'Time taken in computing EM-Bright probabilities = ' + str(end - start) + '\n')        
         exit(0)
@@ -184,7 +185,7 @@ if streamdata['alert_type'] == 'new':
     file_obj.write( json.dumps( {'Prob NS2':NS_prob_2_sngl, 'Prob EMbright':em_bright_prob_sngl} ) )
     file_obj.close()
 
-    gdb.writeLog( graceid, message, filename=filename, tagname=tagnames )
+    #gdb.writeLog( graceid, message, filename=filename, tagname=tagnames )
 
 #     gdb.writeLog(graceid, message, tagname=tagnames)
 


### PR DESCRIPTION
Subject line is the primary modification. Other changes include the following
- Removed pycbc dependence from em_progenitors module
- new function in genDiskMassProbability to calculate probability based on new boundary
- only listen to cbc_gstlal_mdc node

I placed placed the EOS file (equil2D.dat) in my working directory at NEMO. You will find that path currently hardcoded in em_progenitors.py
One suggestion is to probably mention the EOS_path in the configFile.ini. I could work on that apart from using the adding the --options and --flags.
I was to only listen to the MDC node. I ran the code after making these changes and it ran fine on the MDC events.
Deep