### PR TITLE
significant cleaning and rearranging of em_bright_classifier

### DIFF
--- a/bin/em_bright_classifier
+++ b/bin/em_bright_classifier
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
 import os
 import json
-import numpy as np
 import sys
 from sys import stdin
 from sys import exit
+
 import time as Time
 import datetime
-import ConfigParser
-import optparse
+
+import numpy as np
 
 import ligo.gracedb.rest
 from pylal import SnglInspiralUtils
@@ -16,7 +16,10 @@ from pylal import SnglInspiralUtils
 from EM_Bright import genDiskMassProbability
 from EM_Bright import getEllipsoidSamples
 
+import ConfigParser
+import optparse
 
+#########################################################################################
 
 def getCoinc(graceid, gracedb_url, coinc_path, psd_path):
     '''
@@ -29,17 +32,17 @@ def getCoinc(graceid, gracedb_url, coinc_path, psd_path):
 
     try:
         coinc_object = gracedb.files(graceid, "coinc.xml")
-        psd_object = gracedb.files(graceid, "psd.xml.gz")
-
-        coinc_file = open(coinc_path + '/coinc_' + graceid + '.xml', 'w')
-        psd_file = open(psd_path + '/psd_' + graceid + '.xml.gz', 'w')
-
+        coinc_file = open(os.path.join( coinc_path, 'coinc_' + graceid + '.xml'), 'w')
         coinc_file.writelines(coinc_object.read())
-        psd_file.writelines(psd_object.read())
-
         coinc_file.close()
+
+        psd_object = gracedb.files(graceid, "psd.xml.gz")
+        psd_file = open( os.path.join( psd_path, 'psd_' + graceid + '.xml.gz'), 'w')
+        psd_file.writelines(psd_object.read())
         psd_file.close()
+
         return 0
+
     except:
         return 1
 
@@ -47,86 +50,84 @@ def readCoinc(CoincFile):
     '''
     Reads the coinc file. Finds the highest SNR IFO and returns the point estimates of the same.
     '''
-    coinc = SnglInspiralUtils.ReadSnglInspiralFromFiles(CoincFile)
-    ifo=[]; mass1=[]; mass2=[]; chi1=[]; snr= np.array([])
-    for row in coinc:
-        ifo.append(row.ifo)
-        mass1.append(row.mass1)
-        mass2.append(row.mass2)
-        chi1.append(row.spin1z)
-        snr = np.append(snr, row.snr)
-    index = np.argmax(snr) ## To return highest SNR IFO point estimates
+    ifo   = []
+    mass1 = []
+    mass2 = []
+    chi1  = []
+    snr   = []
+    for row in SnglInspiralUtils.ReadSnglInspiralFromFiles( CoincFile ):
+        ifo.append( row.ifo )
+        mass1.append( row.mass1 )
+        mass2.append( row.mass2 )
+        chi1.append( row.spin1z )
+        snr.append( row.snr )
+
+    index = np.argmax( snr ) ## To return highest SNR IFO point estimates
+
     return [mass1[index], mass2[index], chi1[index], snr[index], str(ifo[index])]
 
+######### Options to be parsed from the command line ####################################
 
-######### Options to be parsed from the command line #########
 parser = optparse.OptionParser()
-parser.add_option("-G", "--graceid",action="store",type="string", metavar=" NAME", help="The GraceDB ID of the event on which the EM-Bright codes need to be run.")
-parser.add_option("-C", "--configfile",action="store",type="string", metavar=" NAME", help="The name of the config file")
 
-(opts,args) = parser.parse_args()
+parser.add_option("-G", "--graceid", action="store", type="string", metavar=" NAME", 
+    help="The GraceDB ID of the event on which the EM-Bright codes need to be run.")
 
-#########################################################################################
+parser.add_option("-C", "--configfile", action="store", type="string", metavar=" NAME", 
+    help="The name of the config file")
+
+(opts, args) = parser.parse_args()
 
 ### Sanity checks ###
 if not opts.configfile:
     print 'Must provide config file...'
     exit(1)
-if not opts.configfile:
-    print 'Must provide graceID of the trigger...'
+
+if not opts.graceid:
+    print 'Must provide graceid'
     exit(1)
+
+#########################################################################################
 
 ### Reading information from config file ###
 configParser = ConfigParser.ConfigParser()
 configParser.read( opts.configfile)
-gracedb_url = configParser.get('gracedb', 'gracedb_url')
-coinc_path = configParser.get('Paths', 'coincPath') ## Where coinc files are to be stored
-psd_path = configParser.get('Paths', 'psdPath') ## Where psd files are to be stored
-source_class_path = configParser.get('Paths', 'results') ## Where the result .json file is saved
-log_path = configParser.get('Paths', 'logs')
-numTrials = int( configParser.get('Paths', 'numTrials') ) ## Number of trials to fetch the coinc files.
-wait = float( configParser.get('Paths', 'wait') ) ## Wait time between each trials
 
-ellipsoidSample = int( configParser.get('EMBright', 'elipsoidSample') ) ## Number of samples within ellipsoid on which the EM-Bright analysis will be conducted
-remMassThreshold = float( configParser.get('EMBright', 'remMassThreshold') )
-forced = configParser.getboolean('EMBright', 'Forced')
-gdbwrite = configParser.getboolean('gracedb', 'gdbwrite')
+gracedb_url       = configParser.get('gracedb', 'gracedb_url')
+coinc_path        = configParser.get('Paths', 'coincPath') ## Where coinc files are to be stored
+psd_path          = configParser.get('Paths', 'psdPath') ## Where psd files are to be stored
+source_class_path = configParser.get('Paths', 'results') ## Where the result .json file is saved
+log_path          = configParser.get('Paths', 'logs')
+
+ellipsoidSample  = configParser.getint('EMBright', 'elipsoidSample') ## Number of samples within ellipsoid 
+remMassThreshold = configParser.getfloat('EMBright', 'remMassThreshold')
+
+forced     = configParser.getboolean('EMBright', 'Forced')
+gdbwrite   = configParser.getboolean('gracedb', 'gdbwrite')
 write_text = configParser.getboolean('EMBright', 'writeText')
-f_low = float( configParser.get('EMBright', 'fmin') )
-mc_cut = float( configParser.get('EMBright', 'chirpmass_cut') )
-lowMass_approx = configParser.get('EMBright', 'lowMass_approx')
+
+f_low  = configParser.getfloat('EMBright', 'fmin')
+mc_cut = configParser.getfloat('EMBright', 'chirpmass_cut')
+
+lowMass_approx  = configParser.get('EMBright', 'lowMass_approx')
 highMass_approx = configParser.get('EMBright', 'highMass_approx')
+
 tagnames = configParser.get('gracedb', 'tagnames').split()
 
-'''
-Receives alerts from graceDB, obtains the required coinc and psd files and then launches
-the EM-Bright classification jobs.
-'''
-gdb = ligo.gracedb.rest.GraceDb( gracedb_url )
-### THIS NEEDS TO BE REMOVED ###
-'''
-# Load the LVAlert message contents into a dictionary
-streamdata = json.loads(stdin.read())
+#########################################################################################
 
-#print streamdata
-# Do something with new events having FAR below threshold
-
-# alert_type = 'None'
-# if streamdata['alert_type']:
-#     alert_type = streamdata['alert_type']
-
-if streamdata['alert_type'] == 'new':
-'''
-graceid = opts.graceid
+### set up directories
 try:
     os.system('mkdir -p ' + log_path)
+
 except:
     print 'Could not create logs directory...'
     exit(1)
 
-logFileName = log_path + '/log_' + graceid + '.txt'
+logFileName = log_path + '/log_' + opts.graceid + '.txt'
 log = open(logFileName, 'a')
-log.writelines('\n' + str(datetime.datetime.today()) + '\t' + 'Analyzing event: ' + graceid + '\n')
+log.writelines(str(datetime.datetime.today()) + '\t' + 'Analyzing event: ' + opts.graceid + '\n')
+
 try:
     os.system('mkdir -p ' + coinc_path)
     log.writelines(str(datetime.datetime.today()) + '\t' + 'Successfully created coinc directory\n')
@@ -141,64 +142,105 @@ except:
     log.writelines(str(datetime.datetime.today()) + '\t' + 'Failed to creat coinc and/or psd and/or results directory, Check write privilege to the given path\n')
     exit(1)
 
-for countTrials in xrange(numTrials): ### iterate a maximum of numTrials times
-    log.writelines(str(datetime.datetime.today()) + '\t' + 'Fetching coinc and psd file. Trial number: ' +  str(countTrials+1) + '\n')
-    if getCoinc(graceid, gracedb_url, coinc_path, psd_path): ### this failed, so we sleep
-        Time.sleep(wait)
-    else: ### success! so we exit the loop
-        break
-else: ### we did not break from the loop, so we must have timed out
+#########################################################################################
+
+### fetch coinc and psd files. By assumption, these must exist for this script to be run
+### therefore, we only try to download them once
+
+log.writelines(str(datetime.datetime.today()) + '\t' + 'Fetching coinc and psd file.\n')
+if getCoinc(opts.graceid, gracedb_url, coinc_path, psd_path): ### this failed, so we report that and exit
     log.writelines(str(datetime.datetime.today()) + '\t' + 'Could not fetch coinc and/or psd files\n')
     exit(1)
 
-log.writelines(str(datetime.datetime.today()) + '\t' + 'Successfully fetched coinc and/or psd files\n')
+else:
+    log.writelines(str(datetime.datetime.today()) + '\t' + 'Successfully fetched coinc and/or psd files\n')
 
+#########################
 
-
+### perform the classification computation
 start = Time.time()
-coincFileName = [coinc_path + '/coinc_' + graceid + '.xml']
-[mass1, mass2, chi1, snr, ifo] = readCoinc(coincFileName)
+
+### extract point estimates from search
+[mass1, mass2, chi1, snr, ifo] = readCoinc( [os.path.join(coinc_path, "coinc_"+opts.graceid+".xml")] )
 
 if write_text: ### Write the masses, spin and highest SNR in a text file in the all_coinc directory
-    File = open(coinc_path + '/masses_chi1_' + graceid + '_.dat', 'w')
-    File.writelines(graceid + '\t' + str(mass1) + '\t' +  str(mass2) + '\t' + str(chi1) + '\t' + str(snr) + '\n')
+    File = open( os.path.join(coinc_path,  'masses_chi1_' + opts.graceid + '.dat'), 'w')
+    File.writelines(opts.graceid + '\t' + str(mass1) + '\t' +  str(mass2) + '\t' + str(chi1) + '\t' + str(snr) + '\n')
     File.close()
 
-samples_sngl = getEllipsoidSamples.getSamples(graceid, mass1, mass2, chi1, snr, ellipsoidSample, {ifo + '=' + psd_path + '/psd_' + graceid + '.xml.gz'}, fmin=f_low, NMcs=10, NEtas=10, NChis=10, mc_cut=mc_cut, lowMass_approx=lowMass_approx, highMass_approx=highMass_approx, Forced=forced, logFile=logFileName, saveData=True)
+### generate samples
+samples_sngl = getEllipsoidSamples.getSamples( opts.graceid, 
+                                               mass1, 
+                                               mass2, 
+                                               chi1, 
+                                               snr, 
+                                               ellipsoidSample, 
+                                               {ifo + '=' + os.path.join(psd_path, 'psd_' + opts.graceid + '.xml.gz')}, 
+                                               fmin            = f_low, 
+                                               NMcs            = 10, ### FIXME: should these be hard coded?
+                                               NEtas           = 10, 
+                                               NChis           = 10, 
+                                               mc_cut          = mc_cut, 
+                                               lowMass_approx  = lowMass_approx, 
+                                               highMass_approx = highMass_approx, 
+                                               Forced          = forced, 
+                                               logFile         = logFileName, 
+                                               saveData        = True,
+                                             )
 log.writelines(str(datetime.datetime.today()) + '\t' + 'Created ambiguity ellipsoid samples\n')
 
-### Currently NaNs are generated when the ellipsoid generation failed. This will be changed in subsequent version. ###
-if ~np.any( np.isnan(samples_sngl[0]) ):
-    diskMassObject_sngl = genDiskMassProbability.genDiskMass(samples_sngl, 'test', remMassThreshold)
-    [NS_prob_1_sngl, NS_prob_2_sngl, diskMass_sngl] = diskMassObject_sngl.fromEllipsoidSample()
-    #em_bright_prob_sngl = np.sum((diskMass_sngl > 0.)*100./len(diskMass_sngl))
-    em_bright_prob_sngl = diskMassObject_sngl.computeEMBrightProb() # RE: Probability using new EM bright boundary
-#NS_prob_1_sngl, NS_prob_2_sngl, em_bright_prob_sngl = diskMassObject_sngl.computeEMBrightProb()
-    NS_prob_2_sngl = np.round(NS_prob_2_sngl, 0)
-    em_bright_prob_sngl = np.round(em_bright_prob_sngl, 0)
-    message = 'EM-Bright probabilities computed from detection pipeline: The probability of second object being a neutron star  = ' + str(NS_prob_2_sngl) + '% \n  The probability of remnant mass outside the black hole in excess of ' + str(remMassThreshold) + ' M_sun = '  + str(em_bright_prob_sngl) + '% \n'
+### FIXME: Currently NaNs are generated when the ellipsoid generation failed. 
+###        This will be changed in subsequent version.
+if np.any( np.isnan(samples_sngl[0]) ): ### there were NANs, so we set up point estimate as samples_sngl
+
+    ### report that this failed
+    log.writelines(str(datetime.datetime.today()) + '\t' + 'Ellipsoid generation failed. Computing probabilities from trigger point estimates. \n')
+
+    ### set up the "samples" as a single point estimate
+    mchirp = ((mass1 * mass2)**(3./5.))/((mass1 + mass2)**(1./5.))
+    eta    = (mass1 * mass2)/((mass1 + mass2)**2)
+
+    samples_sngl = np.array([[ mchirp, eta, chi1]])
+
+    ### ensure this will *not* be labeled "lvem"
+    ### FIXME: we hard code this for the moment, but may want to specify this up in the config file
+    if "lvem" in tagnames:
+        tagnames.remove("lvem")
+
+    ### begin message for GraceDb specifying how samples were generated
+    message = 'Ellipsoid generation code failed. Computing EM-Bright probabilities from triggered point estimates: '
 
 else:
-    log.writelines(str(datetime.datetime.today()) + '\t' + 'Ellipsoid generation failed. Computing probabilities from trigger point estimates. \n')
-    mchirp = ((mass1 * mass2)**(3./5.))/((mass1 + mass2)**(1./5.))
-    eta = (mass1 * mass2)/((mass1 + mass2)**2)
-    point_etimate = np.array([[ mchirp, eta, chi1]])
-    diskMassObject_sngl = genDiskMassProbability.genDiskMass(point_etimate, 'test', remMassThreshold)
-    [NS_prob_1_sngl, NS_prob_2_sngl, diskMass_sngl] = diskMassObject_sngl.fromEllipsoidSample()
-    em_bright_prob_sngl = diskMassObject_sngl.computeEMBrightProb() # RE: Using same function as in if block above
-    NS_prob_2_sngl = np.round(NS_prob_2_sngl, 0)
-    em_bright_prob_sngl = np.round(em_bright_prob_sngl, 0)
-    message = 'Ellipsoid generation code failed. Computing EM-Bright probabilities from triggered point estimates: The probability of second object being a neutron star  = ' + str(NS_prob_2_sngl) + '% \n  The probability of remnant mass outside the black hole in excess of ' + str(remMassThreshold) + ' M_sun = '  + str(em_bright_prob_sngl) + '% \n'
+    ### begin message for GraceDb specifying how samples were generated
+    message = 'EM-Bright probabilities computed from detection pipeline: '
+
+#########################
+### compute probabilities
+
+### instantiate our object
+diskMassObject_sngl = genDiskMassProbability.genDiskMass(samples_sngl, 'test', remMassThreshold)
+
+### compute probabilities
+_, NS_prob_2_sngl, _ = diskMassObject_sngl.fromEllipsoidSample()
+em_bright_prob_sngl  = diskMassObject_sngl.computeEMBrightProb()
+
+### round probabilities
+NS_prob_2_sngl      = np.round(NS_prob_2_sngl, 0)
+em_bright_prob_sngl = np.round(em_bright_prob_sngl, 0)
+
+### format message for GraceDb
+message += 'The probability of second object being a neutron star  = ' + str(NS_prob_2_sngl) + '% \n  The probability of remnant mass outside the black hole in excess of ' + str(remMassThreshold) + ' M_sun = '  + str(em_bright_prob_sngl) + '% \n'
 
 end = Time.time()
 log.writelines(str(datetime.datetime.today()) + '\t' + 'Time taken in computing EM-Bright probabilities = ' + str(end - start) + '\n')
 
-filename = source_class_path + '/Source_Classification_' + graceid + '_.json'
+### save output
+filename = os.path.join(source_class_path, 'Source_Classification_' + opts.graceid + '.json')
 file_obj = open(filename, 'w')
 file_obj.write( json.dumps( {'Prob NS2':NS_prob_2_sngl, 'Prob EMbright':em_bright_prob_sngl} ) )
 file_obj.close()
 
-#gdb.writeLog( graceid, message, filename=filename, tagname=tagnames )
+### upload to GraceDb
 if gdbwrite:
-    gdb.writeLog(graceid, message, filename=filename, tagname=tagnames)
-
+    gdb = ligo.gracedb.rest.GraceDb( gracedb_url )
+    gdb.writeLog(opts.graceid, message, filename=filename, tagname=tagnames)

--- a/etc/emBright.ini
+++ b/etc/emBright.ini
@@ -1,22 +1,22 @@
 [Paths]
 coincPath = ./em_bright
-psdPath = ./em_bright
-results = ./em_bright
-logs = ./logs
-numTrials = 5
-wait = 5
+psdPath   = ./em_bright
+results   = ./em_bright
+logs      = ./logs
 
 [EMBright]
-elipsoidSample = 1000
+elipsoidSample   = 1000
 remMassThreshold = 0.0
-fmin = 30
-Forced = False
-chirpmass_cut = 2.612
-lowMass_approx = lalsim.SpinTaylorT4
+
+fmin            = 30
+chirpmass_cut   = 2.612
+lowMass_approx  = lalsim.SpinTaylorT4
 highMass_approx = lalsim.IMRPhenomPv2
+
+Forced    = False
 writeText = True
 
 [gracedb]
 gracedb_url = https://gracedb.ligo.org/api/
-tagnames = em_follow lvem
-gdbwrite = True
+tagnames    = em_follow lvem
+gdbwrite    = True


### PR DESCRIPTION
I modified em_bright_classifier, removing as much unnecessary code as possible. Also added a hard-coded statement to ensure that log messages will *not* be labeled "lvem" if the ellipsoid generation failed. This also includes cleaning up a few filenames so there are no trailing "_" before the suffix.

I've tested this and the functionality appears to be maintained. I've merely made the code more readable (and robust), in my opinion.